### PR TITLE
Parse origin URLs with no .git appendix

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -39,7 +39,7 @@
 
 (defun browse-at-remote/parse-https-prefixed (origin)
   "Extract domain and slug from origin like https://...."
-  (let ((matches (s-match "https://\\(?:[a-z]+@\\)?\\([a-z\.]+\\)/\\([a-z\-]+/[a-z\.\-]+\\)" origin)))
+  (let ((matches (s-match "https://\\(?:[a-z]+@\\)?\\([a-z0-9\.-]+\\)/\\([a-z\-]+/[a-z0-9\.\-]+\\)" origin)))
     (list (nth 1 matches)
           (file-name-sans-extension (nth 2 matches)))))
 

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -39,9 +39,9 @@
 
 (defun browse-at-remote/parse-https-prefixed (origin)
   "Extract domain and slug from origin like https://...."
-  (nthcdr
-   2
-   (s-match "https://\\([a-z]+@\\)?\\([a-z\.]+\\)/\\([a-z\-]+/[a-z\.\-]+\\).git" origin)))
+  (let ((matches (s-match "https://\\(?:[a-z]+@\\)?\\([a-z\.]+\\)/\\([a-z\-]+/[a-z\.\-]+\\)" origin)))
+    (list (nth 1 matches)
+          (file-name-sans-extension (nth 2 matches)))))
 
 (defun browse-at-remote/get-url-from-origin (origin)
   "Extract browseable repo url from origin definition"


### PR DESCRIPTION
HTTPS parsing now matches both of the following:

* https://github.com/rmuslimov/browse-at-remote
* https://github.com/rmuslimov/browse-at-remote.git

And browses properly to https://github.com/rmuslimov/browse-at-remote.