### PR TITLE
Git url without ending

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -36,7 +36,7 @@
 
 (defun browse-at-remote/parse-git-prefixed (origin)
   "Extract domain and slug for origin like git@..."
-  (cdr (s-match "git@\\([a-z\.]+\\):\\([a-z\.\-]+/[a-z0-9\.\-]+\\).git" origin)))
+  (cdr (s-match "git@\\([a-z.]+\\):\\([a-z.-]+/[a-z0-9.-]+?\\)\\(?:\.git\\)?$" origin)))
 
 (defun browse-at-remote/parse-https-prefixed (origin)
   "Extract domain and slug from origin like https://...."

--- a/test/api-basic-test.el
+++ b/test/api-basic-test.el
@@ -33,4 +33,6 @@
 				 (cons `"github.com" `"https://github.com/rmuslimov/browse-at-remote")))
   (should (equal (browse-at-remote/get-url-from-origin "https://github.com/rmus2limov/brows2e-at-remote")
 				 (cons `"github.com" `"https://github.com/rmus2limov/brows2e-at-remote")))
+  (should (equal (browse-at-remote/get-url-from-origin "git@github.com:someplace/without-ending")
+                                 (cons `"github.com" `"https://github.com/someplace/without-ending")))
   )


### PR DESCRIPTION
Support repos with remotes like `git@github.com:someplace/without-ending`.