### PR TITLE
Use `git ls-remote --get-url origin`

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -57,7 +57,7 @@
 (defun browse-at-remote/get-origin ()
   "Get origin from current repo"
   (with-temp-buffer
-    (vc-git--call t "config" "--get" "remote.origin.url")
+    (vc-git--call t "ls-remote" "--get-url" "origin")
     (s-replace "\n" "" (buffer-string))))
 
 (defun browse-at-remote/get-remote-type-from-config ()


### PR DESCRIPTION
`git config --get remote.origin.url` does not respect `url.<base>.insteadOf` config settings. `git ls-remote --get-url` does perform this expansion (without talking to the remote, as it does when invoked without `--get-url`).

This allows `browse-at-url` to work with repos that have remotes that rely on URL rewriting as well as plain remotes.

Note that `git ls-remote --get-url` requires Git version 1.7.5, [released in 2011][relnote].

References:

- https://www.git-scm.com/docs/git-ls-remote (`--get-url`)
- https://www.git-scm.com/docs/git-config (`url.<base>.insteadOf`)

[relnote]: https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.5.txt