### PR TITLE
Fix package

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -33,6 +33,7 @@
 (require 'f)
 (require 's)
 (require 'cl-lib)
+(require 'vc-git)
 
 (defgroup browse-at-remote nil
   "Open target on github/gitlab/bitbucket"
@@ -134,7 +135,7 @@
   "Commit URL formatted for github"
   (format "%s/commit/%s" repo-url commithash))
 
-(defun browse-at-remote/format-region-url-as-bitbucket (repo-url location filename &optional linestart lineend)
+(defun browse-at-remote/format-region-url-as-bitbucket (repo-url location filename &optional linestart _lineend)
   "URL formatted for bitbucket"
   (cond
    (linestart (format "%s/src/%s/%s#cl-%d" repo-url location filename linestart))
@@ -211,7 +212,7 @@ Currently the same as for github."
    ;; magit-commit-mode
    ((eq major-mode 'magit-commit-mode)
     (save-excursion
-      (beginning-of-buffer)
+      (goto-char (point-min))
       (let* ((first-line
               (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
              (commithash (car (s-split " " first-line))))

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -1,5 +1,4 @@
-;; -*- lexical-binding:t -*-
-;;; browse-at-remote.el --- Open github/gitlab/bitbucket page from Emacs
+;;; browse-at-remote.el --- Open github/gitlab/bitbucket page from Emacs -*- lexical-binding:t -*-
 
 ;; Copyright © 2015 Rustem Muslimov
 ;;

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -5,7 +5,7 @@
 ;; Author:     Rustem Muslimov <r.muslimov@gmail.com>
 ;; Version:    0.7.0
 ;; Keywords:   github, gitlab, bitbucket, convenience
-;; Package-Requires: ((f "0.17.2") (s "1.9.0"))
+;; Package-Requires: ((f "0.17.2") (s "1.9.0") (cl-lib "0.5"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -32,6 +32,7 @@
 
 (require 'f)
 (require 's)
+(require 'cl-lib)
 
 (defgroup browse-at-remote nil
   "Open target on github/gitlab/bitbucket"
@@ -108,9 +109,9 @@
          (remote-type-from-config (browse-at-remote/get-remote-type-from-config)))
     (if (member remote-type-from-config '("github" "bitbucket" "gitlab"))
         remote-type-from-config
-      (loop for pt in browse-at-remote/remote-type-domains
-            when (string= (car pt) domain)
-            return (cdr pt))))
+      (cl-loop for pt in browse-at-remote/remote-type-domains
+               when (string= (car pt) domain)
+               return (cdr pt))))
 
    (error (format "Sorry, not sure what to do with repo `%s'" target-repo))))
 


### PR DESCRIPTION
- Fix package header
- Load cl-lib for using loop macro
- Fix byte-compile warnings

There are following byte-compile warnings.

```
In browse-at-remote/get-remote-type:
browse-at-remote.el:112:13:Warning: reference to free variable `for'
browse-at-remote.el:112:17:Warning: reference to free variable `pt'
browse-at-remote.el:112:20:Warning: reference to free variable `in'
browse-at-remote.el:113:13:Warning: reference to free variable `when'
browse-at-remote.el:114:13:Warning: reference to free variable `return'
browse-at-remote.el:137:1:Warning: Unused lexical argument `lineend'
                                                                                  
In browse-at-remote/get-url:
browse-at-remote.el:212:21:Warning: `beginning-of-buffer' is for interactive
    use only; use `(goto-char (point-min))' instead.

In end of data:
browse-at-remote.el:266:1:Warning: the following functions are not known to be defined: vc-git--call,
    loop, vc-git-working-revision, vc-git-root 
```