### PR TITLE
Fix remotes

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -44,9 +44,8 @@
   '(("bitbucket.org" ."bitbucket")
     ("github.com" . "github")
     ("gitlab.com" . "gitlab"))
-  "Alist of domain patterns to remote types.
+  "Alist of domain patterns to remote types."
 
-   For remote URLs matching these domain patterns, "
   :type '(alist :key-type (string :tag "Domain")
                 :value-type (choice
                              (const :tag "GitHub" "github")

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -53,6 +53,16 @@
                              (const :tag "BitBucket" "bitbucket")))
   :group 'browse-at-remote)
 
+(defcustom browse-at-remote/prefer-symbolic t
+  "Whether to prefer symbolic references when linking.
+
+When t, uses the branch name, if available. This generates easier to
+read URLs, but for long-lived links, the content of the linked file
+may change, producing link rot.
+
+When nil, uses the commit hash. The contents will never change."
+  :type 'boolean
+  :group 'browse-at-remote)
 
 (defun browse-at-remote/parse-git-prefixed (remote-url)
   "Extract domain and slug from REMOTE-URL like git@..."
@@ -76,16 +86,24 @@
          (slug (nth 1 parsed)))
     (cons domain (format "%s://%s/%s" proto domain slug))))
 
-(defun browse-at-remote/get-origin ()
-  "Get origin from current repo.
+(defun browse-at-remote/remote-ref (&optional filename)
+  "Return the remote & commit ref which FILENAME is in.
 
-   Looks for a remote named \"origin\"; if this doesn't exist, returns
-   the first remote from the list of all known remotes."
-  (let ((remotes (browse-at-remote/get-remotes)))
-    (browse-at-remote/get-remote-url
-     (or (car (member "origin" remotes))
-         (car remotes)
-         (error "No remotes in this repo.")))))
+Returns (REMOTE-URL . REF) or nil, if the local branch doesn't track a remote."
+  (let* ((local-branch (vc-git-working-revision (or filename ".")))
+         (remote (and local-branch (browse-at-remote/get-from-config
+                                    (format "branch.%s.remote" local-branch))))
+         (remote (when remote (browse-at-remote/get-remote-url remote)))
+         (remote-branch
+          (s-chop-prefix "refs/heads/"
+                         (and local-branch (browse-at-remote/get-from-config
+                                            (format "branch.%s.merge" local-branch))))))
+    (unless (and (string= remote "")
+                 (string= remote-branch ""))
+      (cons remote
+            (if (not browse-at-remote/prefer-symbolic)
+                (vc-git--rev-parse "HEAD")
+              remote-branch)))))
 
 (defun browse-at-remote/get-remote-url (remote)
   "Get URL of REMOTE from current repo."
@@ -167,7 +185,8 @@ Currently the same as for github."
 
 (defun browse-at-remote/commit-url (commithash)
   "Return the URL to browse COMMITHASH."
-  (let* ((target-repo (browse-at-remote/get-url-from-origin (browse-at-remote/get-origin)))
+  (let* ((remote (car (browse-at-remote/remote-ref)))
+         (target-repo (browse-at-remote/get-url-from-remote remote))
          (repo-url (cdr target-repo))
          (remote-type (browse-at-remote/get-remote-type target-repo))
          (clear-commithash (s-chop-prefixes '("^") commithash))
@@ -178,9 +197,11 @@ Currently the same as for github."
 
 (defun browse-at-remote/file-url (filename &optional start end)
   "Return the URL to browse FILENAME from lines START to END. "
-  (let* ((branch (vc-git-working-revision filename))
+  (let* ((remote-ref (browse-at-remote/remote-ref filename))
+         (remote (car remote-ref))
+         (ref (cdr remote-ref))
          (relname (f-relative filename (f-expand (vc-git-root filename))))
-         (target-repo (browse-at-remote/get-url-from-origin (browse-at-remote/get-origin)))
+         (target-repo (browse-at-remote/get-url-from-remote remote))
          (remote-type (browse-at-remote/get-remote-type target-repo))
          (repo-url (cdr target-repo))
          (url-formatter (browse-at-remote/get-formatter 'region-url remote-type))
@@ -189,7 +210,7 @@ Currently the same as for github."
     (unless url-formatter
       (error (format "Origin repo parsing failed: %s" repo-url)))
 
-    (funcall url-formatter repo-url branch relname
+    (funcall url-formatter repo-url ref relname
              (if start-line start-line)
              (if (and end-line (not (equal start-line end-line))) end-line))))
 

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -53,24 +53,25 @@
                              (const :tag "BitBucket" "bitbucket")))
   :group 'browse-at-remote)
 
-(defun browse-at-remote/parse-git-prefixed (origin)
-  "Extract domain and slug from ORIGIN like git@..."
-  (cdr (s-match "git@\\([a-z.]+\\):\\([a-z0-9_.-]+/[a-z0-9_.-]+?\\)\\(?:\.git\\)?$" origin)))
 
-(defun browse-at-remote/parse-https-prefixed (origin)
-  "Extract domain and slug from ORIGIN like https://.... or http://...."
-  (let ((matches (s-match "https?://\\(?:[a-z]+@\\)?\\([a-z0-9.-]+\\)/\\([a-z0-9_-]+/[a-z0-9_.-]+\\)" origin)))
+(defun browse-at-remote/parse-git-prefixed (remote-url)
+  "Extract domain and slug from REMOTE-URL like git@..."
+  (cdr (s-match "git@\\([a-z.]+\\):\\([a-z0-9_.-]+/[a-z0-9_.-]+?\\)\\(?:\.git\\)?$" remote-url)))
+
+(defun browse-at-remote/parse-https-prefixed (remote-url)
+  "Extract domain and slug from REMOTE-URL like https://.... or http://...."
+  (let ((matches (s-match "https?://\\(?:[a-z]+@\\)?\\([a-z0-9.-]+\\)/\\([a-z0-9_-]+/[a-z0-9_.-]+\\)" remote-url)))
     (list (nth 1 matches)
           (file-name-sans-extension (nth 2 matches)))))
 
-(defun browse-at-remote/get-url-from-origin (origin)
-  "Extract browseable repo url from ORIGIN."
+(defun browse-at-remote/get-url-from-remote (remote-url)
+  "Return (DOMAIN . URL) from REMOTE-URL."
   (let* ((parsed
           (cond
-           ((s-starts-with? "git" origin) (browse-at-remote/parse-git-prefixed origin))
-           ((s-starts-with? "http" origin) (browse-at-remote/parse-https-prefixed origin))))
+           ((s-starts-with? "git" remote-url) (browse-at-remote/parse-git-prefixed remote-url))
+           ((s-starts-with? "http" remote-url) (browse-at-remote/parse-https-prefixed remote-url))))
          (proto
-          (if (s-starts-with? "http:" origin) "http" "https"))
+          (if (s-starts-with? "http:" remote-url) "http" "https"))
          (domain (car parsed))
          (slug (nth 1 parsed)))
     (cons domain (format "%s://%s/%s" proto domain slug))))

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -103,9 +103,12 @@
 
 (defun browse-at-remote/get-remote-type-from-config ()
   "Get remote type from current repo."
+  (browse-at-remote/get-from-config "browseAtRemote.type"))
+
+(defun browse-at-remote/get-from-config (key)
   (with-temp-buffer
-    (vc-git--call t "config" "--get" "browseAtRemote.type")
-    (s-replace "\n" "" (buffer-string))))
+    (vc-git--call t "config" "--get" key)
+    (s-trim (buffer-string))))
 
 (defun browse-at-remote/get-remote-type (target-repo)
   (or


### PR DESCRIPTION
See @9ce3311 for details, but in a nutshell, b-a-rm assumed that the upstream branch name was identical to the local, which isn't always the case.