### PR TITLE
Unable to browse at remote a file in a repository cloned (not forked) from Github

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -66,7 +66,7 @@ When nil, uses the commit hash. The contents will never change."
 
 (defun browse-at-remote/parse-git-prefixed (remote-url)
   "Extract domain and slug from REMOTE-URL like git@..."
-  (cdr (s-match "git@\\([a-z.]+\\):\\([a-z0-9_.-]+/[a-z0-9_.-]+?\\)\\(?:\.git\\)?$" remote-url)))
+  (cdr (s-match "git\\(?:@\\|://\\)\\([a-z.]+\\)\\(?::\\|/\\)\\([a-z0-9_.-]+/[a-z0-9_.-]+?\\)\\(?:\.git\\)?$" remote-url)))
 
 (defun browse-at-remote/parse-https-prefixed (remote-url)
   "Extract domain and slug from REMOTE-URL like https://.... or http://...."

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -65,7 +65,7 @@ When nil, uses the commit hash. The contents will never change."
   :group 'browse-at-remote)
 
 (defun browse-at-remote/parse-git-prefixed (remote-url)
-  "Extract domain and slug from REMOTE-URL like git@..."
+  "Extract domain and slug from REMOTE-URL like git@... or git://..."
   (cdr (s-match "git\\(?:@\\|://\\)\\([a-z.]+\\)\\(?::\\|/\\)\\([a-z0-9_.-]+/[a-z0-9_.-]+?\\)\\(?:\.git\\)?$" remote-url)))
 
 (defun browse-at-remote/parse-https-prefixed (remote-url)


### PR DESCRIPTION
I have a repository which was cloned (not forked) from Github using `hub clone marijnh/tern`.
The setup of the `origin` remote is:
```sh
$ git remote -v
origin	git://github.com/marijnh/tern.git (fetch)
origin	git://github.com/marijnh/tern.git (push)
```
When I try to browse at remote the file `lib/typescript.js`, I receive the following message:
```
browse-at-remote/get-remote-type: Sorry, not sure what to do with repo `(nil . https://nil/nil)'
```
Toggling debug on error gives the following backtrace:
```
Debugger entered--Lisp error: (error "Sorry, not sure what to do with repo `(nil . https://nil/nil)'")
  signal(error ("Sorry, not sure what to do with repo `(nil . https://nil/nil)'"))
  error("Sorry, not sure what to do with repo `(nil . https://nil/nil)'")
  browse-at-remote/get-remote-type((nil . "https://nil/nil"))
  browse-at-remote/file-url("/home/miki/vcs/git/node-modules/tern/lib/typescript.js" 173)
  browse-at-remote/get-url()
  browse-at-remote/browse()
  call-interactively(browse-at-remote/browse nil nil)
  command-execute(browse-at-remote/browse)
```
Stepping into `browse-at-remote/get-url`, I found that the function `browse-at-remote/parse-git-prefixed` uses a regexp which only matches URLs which start with `git@`, which is not the case for my repository.
I suspect this could be the reason for the broken `https://nil/nil` URL.