### PR TITLE
obey browse-at-remote-prefer-symbolic

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -90,9 +90,10 @@ When nil, uses the commit hash. The contents will never change."
   "Return (REMOTE-URL . REF) which contains FILENAME.
 Returns nil if no appropriate remote or ref can be found."
   (let ((local-branch (browse-at-remote--get-local-branch))
-        (revision (if (fboundp 'vc-git--symbolic-ref)
-                           (vc-git--symbolic-ref (or filename "."))
-                         (vc-git-working-revision (or filename "."))))
+        (revision (if (and (fboundp 'vc-git--symbolic-ref)
+                           browse-at-remote-prefer-symbolic)
+                      (vc-git--symbolic-ref (or filename "."))
+                    (vc-git-working-revision (or filename "."))))
         remote-branch
         remote-name)
     ;; If we're on a branch, try to find a corresponding remote


### PR DESCRIPTION
This is a simple change that fixes #27 so that it'll always use the revision when the `prefer-symbolic` option is set to `nil`. Otherwise, as before, it'll use the symbolic ref if it's non-nil and the `vc-git--symbolic-ref` function is bound.