### PR TITLE
Highlight single-line correctly in BitBucket

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -209,8 +209,10 @@ If HEAD is detached, return nil."
 (defun browse-at-remote--format-region-url-as-bitbucket (repo-url location filename &optional linestart lineend)
   "URL formatted for bitbucket"
   (cond
-   (linestart (format "%s/src/%s/%s#cl-%d:%d" repo-url location filename linestart lineend))
-   (t (format "%s/src/%s/%s" repo-url location filename))))
+   ((and linestart lineend)
+    (format "%s/src/%s/%s#cl-%d:%d" repo-url location filename linestart lineend))
+   (linestart (format "%s/src/%s/%s#cl-%d" repo-url location filename linestart))
+   (t (format "%s/tree/%s/%s" repo-url location filename))))
 
 (defun browse-at-remote--format-commit-url-as-bitbucket (repo-url commithash)
   "Commit URL formatted for bitbucket"


### PR DESCRIPTION
Adding support for region highlight (#30) accidentally broke single-line highlight in BitBucket. Here's a fix for it, now supporting both single-line and region highlights.