### PR TITLE
Fix BitBucket directory path

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -213,7 +213,7 @@ If HEAD is detached, return nil."
    ((and linestart lineend)
     (format "%s/src/%s/%s#cl-%d:%d" repo-url location filename linestart lineend))
    (linestart (format "%s/src/%s/%s#cl-%d" repo-url location filename linestart))
-   (t (format "%s/tree/%s/%s" repo-url location filename))))
+   (t (format "%s/src/%s/%s" repo-url location filename))))
 
 (defun browse-at-remote--format-commit-url-as-bitbucket (repo-url commithash)
   "Commit URL formatted for bitbucket"


### PR DESCRIPTION
Currently running `browse-at-remote` in a Dired buffer gives you 404 since the link generated is incorrect.

https://bitbucket.org/mituharu/emacs-mac/src/master/lisp/ instead of https://bitbucket.org/mituharu/emacs-mac/tree/master/lisp/ (404)