### PR TITLE
Fix nested remote urls

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -66,11 +66,11 @@ When nil, uses the commit hash. The contents will never change."
 
 (defun browse-at-remote--parse-git-prefixed (remote-url)
   "Extract domain and slug from REMOTE-URL like git@... or git://..."
-  (cdr (s-match "[git\\|ssh]\\(?:@\\|://\\)\\([a-z.]+\\)\\(?::\\|/\\)\\([a-z0-9_.-]+/[a-z0-9_.-]+?\\)\\(?:\.git\\)?$" remote-url)))
+  (cdr (s-match "[git\\|ssh]\\(?:@\\|://\\)\\([a-z.]+\\)\\(?::\\|/\\)\\(\\([a-z0-9_.-]+/\\)+[a-z0-9_.-]+?\\)\\(?:\.git\\)?$" remote-url)))
 
 (defun browse-at-remote--parse-https-prefixed (remote-url)
   "Extract domain and slug from REMOTE-URL like https://.... or http://...."
-  (let ((matches (s-match "https?://\\(?:[a-z]+@\\)?\\([a-z0-9.-]+\\)/\\([a-z0-9_-]+/[a-z0-9_.-]+\\)" remote-url)))
+  (let ((matches (s-match "https?://\\(?:[a-z]+@\\)?\\([a-z0-9.-]+\\)/\\(\\([a-z0-9_-]+/\\)+[a-z0-9_.-]+\\)" remote-url)))
     (list (nth 1 matches)
           (file-name-sans-extension (nth 2 matches)))))
 

--- a/test/api-basic-test.el
+++ b/test/api-basic-test.el
@@ -18,6 +18,8 @@
                  (cons `"github.com" `"https://github.com/someplace/with-dash.el")))
   (should (equal (browse-at-remote--get-url-from-remote "git@github.com:someplace/wi2th-dash.el.git")
                  (cons `"github.com" `"https://github.com/someplace/wi2th-dash.el")))
+  (should (equal (browse-at-remote--get-url-from-remote "git@gitlab.com:someplace/double-nested/wi2th-dash.el.git")
+                 (cons `"gitlab.com" `"https://gitlab.com/someplace/double-nested/wi2th-dash.el")))
   )
 
 (ert-deftest get-https-repo-url-test ()
@@ -35,6 +37,8 @@
 				 (cons `"github.com" `"https://github.com/with_underscores/pro-digy_underscores.el")))
   (should (equal (browse-at-remote--get-url-from-remote "https://github.com/rmuslimov/browse-at-remote.git")
 				 (cons `"github.com" `"https://github.com/rmuslimov/browse-at-remote")))
+  (should (equal (browse-at-remote--get-url-from-remote "https://gitlab.com/someplace/double-nested/wi2th-dash.el.git")
+                 (cons `"gitlab.com" `"https://gitlab.com/someplace/double-nested/wi2th-dash.el")))
   )
 
 (ert-deftest get-https-repo-url-without-ending ()


### PR DESCRIPTION
On gitlab you can have repos multiple levels(/folders) deep.
So `https://gitlab.com/foo/bar/blub` is valid.