### PR TITLE
Improvements to remote domain alist

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -178,16 +178,17 @@ If HEAD is detached, return nil."
     (s-trim (buffer-string))))
 
 (defun browse-at-remote--get-remote-type (target-repo)
-  (or
-   (let* ((domain (car target-repo))
+  (let* ((domain (car target-repo))
          (remote-type-from-config (browse-at-remote--get-remote-type-from-config)))
-    (if (member remote-type-from-config '("github" "bitbucket" "gitlab" "stash"))
-        remote-type-from-config
-      (cl-loop for pt in browse-at-remote-remote-type-domains
-               when (string= (car pt) domain)
-               return (cdr pt))))
+    (or
+     (if (member remote-type-from-config '("github" "bitbucket" "gitlab" "stash"))
+         remote-type-from-config
+       (cl-loop for pt in browse-at-remote-remote-type-domains
+                when (string= (car pt) domain)
+                return (cdr pt)))
 
-   (error (format "Sorry, not sure what to do with repo `%s'" target-repo))))
+     (error (format "Sorry, not sure what to do with domain `%s' (consider adding it to `browse-at-remote-remote-type-domains')"
+                    domain)))))
 
 (defun browse-at-remote--get-formatter (formatter-type remote-type)
   "Get formatter function for given FORMATTER-TYPE (region-url or commit-url) and REMOTE-TYPE (github or bitbucket)"

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -50,7 +50,8 @@
                 :value-type (choice
                              (const :tag "GitHub" "github")
                              (const :tag "GitLab" "gitlab")
-                             (const :tag "BitBucket" "bitbucket")))
+                             (const :tag "Bitbucket" "bitbucket")
+                             (const :tag "Stash/BitBucket Server" "stash")))
   :group 'browse-at-remote)
 
 (defcustom browse-at-remote-prefer-symbolic t


### PR DESCRIPTION
This is a really useful feature in browse-at-remote that deserves more visibility to the user :)

I've tweaked `browse-at-remote--get-remote-type` to suggest configuring `browse-at-remote-remote-type-domains` if that's what the user needs to do.

I've also added `"stash"` as a value suggested by Customize for `browse-at-remote-remote-type-domains`, which was previously not documented there.