### PR TITLE
Add support for Phabricator URLs

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -54,7 +54,8 @@
                              (const :tag "GitLab" "gitlab")
                              (const :tag "Bitbucket" "bitbucket")
                              (const :tag "Stash/Bitbucket Server" "stash")
-                             (const :tag "git.savannah.gnu.org" "gnu")))
+                             (const :tag "git.savannah.gnu.org" "gnu")
+							 (const :tag "Phabricator" "phabricator")))
   :group 'browse-at-remote)
 
 (defcustom browse-at-remote-prefer-symbolic t
@@ -267,6 +268,19 @@ If HEAD is detached, return nil."
 (defun browse-at-remote--format-commit-url-as-stash (repo-url commithash)
   "Commit URL formatted for stash"
   (format "%s/commits/%s" (browse-at-remote--fix-repo-url-stash repo-url) commithash))
+
+(defun browse-at-remote--format-region-url-as-phabricator (repo-url location filename &optional linestart lineend)
+  "URL formatted for Phabricator"
+  	(let* ((lines (cond
+                 (lineend (format "\$%d-%d" linestart lineend))
+                 (linestart (format "\$%d" linestart))
+                 (t ""))))
+  (format "%s/browse/%s/%s%s" repo-url location filename lines)))
+
+(defun browse-at-remote--format-commit-url-as-phabricator (repo-url commithash)
+  "Commit URL formatted for Phabricator"
+  (message repo-url)
+  (format "%s/%s%s" (replace-regexp-in-string "\/source/.*" "" repo-url)  (read-string "Please input the callsign for this repository:") commithash))
 
 (defun browse-at-remote--format-region-url-as-gitlab (repo-url location filename &optional linestart lineend)
   "URL formatted for gitlab.


### PR DESCRIPTION
Had some issues with generating a commit URL, because Phabricator uses reposiotories' callsigns for that and those aren't included in the repository URL. In the end I've decided to just ask the user for the callsign when generating a commit URL. File/region URLs work just fine