### PR TITLE
Reliably extract SHA1 from magit-revision buffers

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -372,10 +372,13 @@ Currently the same as for github."
    ;; magit-commit-mode and magit-revision-mode
    ((or (eq major-mode 'magit-commit-mode) (eq major-mode 'magit-revision-mode))
     (save-excursion
+      ;; Search for the SHA1 on the first line.
       (goto-char (point-min))
       (let* ((first-line
               (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
-             (commithash (car (s-split " " first-line))))
+             (commithash (cl-loop for word in (s-split " " first-line)
+                                  when (eq 40 (length word))
+                                  return word)))
         (browse-at-remote--commit-url commithash))))
 
    ;; log-view-mode


### PR DESCRIPTION
Hi @rmuslimov 

Thanks for your work on the browse-at-remote package. It's become a major part of my daily workflows. 

Recently, I've encountered issues with some magit buffers. In particular, the first line on the magit-revision buffer sometimes contains extra information before the SHA1. Examples:

    origin/master 895e60b602f23d694674d977f24bd7a213a03aa6
    0.10.0 47bab994640f086939c30cc6416e770ad067e950

Here is a quick patch to handle these cases.