### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+dist: xenial
+language: emacs-lisp
+addons:
+  apt:
+    update: true
+
+jobs:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
+  include:
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-24.5-travis
+      script: &build
+        - rm -rf $HOME/.evm
+        - travis_retry eval $"git clone https://github.com/rejeep/evm.git $HOME/.evm ; sleep 10"
+        - export PATH=$HOME/.evm/bin:$HOME/.cask/bin:$PATH
+        - evm config path /tmp
+        - travis_retry eval $"evm install $EVM_EMACS --use --skip ; sleep 10"
+        - emacs --version
+        - travis_retry eval $"curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python ; sleep 10"
+        - travis_retry eval $"cask install ; sleep 10"
+        - cask build
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-25.3-travis
+      script: *build
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-26.3-travis-linux-xenial
+      script: *build
+    - stage: build
+      env:
+        - EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
+      script: *build

--- a/readme.rst
+++ b/readme.rst
@@ -1,6 +1,9 @@
 .. image:: http://melpa.org/packages/browse-at-remote-badge.svg
    :target: http://melpa.org/#/browse-at-remote
 
+.. image:: https://travis-ci.org/rmuslimov/browse-at-remote.svg?branch=master
+    :target: https://travis-ci.org/rmuslimov/browse-at-remote
+
 browse-at-remote.el
 ===================
 


### PR DESCRIPTION
Travis CI coverage. Closely copied from Helm: https://github.com/emacs-helm/helm/blob/master/.travis.yml

Succeeds: https://travis-ci.org/peterbecich/browse-at-remote/builds/629572118