### PR TITLE
Add support for pagure.io

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -47,7 +47,9 @@
     ("gitlab.com" . "gitlab")
     ("git.savannah.gnu.org" . "gnu")
     ("gist.github.com" . "gist")
-    ("git.sr.ht" . "sourcehut"))
+    ("git.sr.ht" . "sourcehut")
+    ("pagure.io" . "pagure")
+    ("src.fedoraproject.org" . "pagure"))
   "Alist of domain patterns to remote types."
 
   :type '(alist :key-type (string :tag "Domain")
@@ -59,7 +61,8 @@
                              (const :tag "git.savannah.gnu.org" "gnu")
                              (const :tag "Phabricator" "phabricator")
                              (const :tag "gist.github.com" "gist")
-                             (const :tag "sourcehut" "sourcehut")))
+                             (const :tag "sourcehut" "sourcehut")
+                             (const :tag "pagure" "pagure")))
   :group 'browse-at-remote)
 
 (defcustom browse-at-remote-prefer-symbolic t
@@ -329,6 +332,23 @@ Currently the same as for github."
 (defun browse-at-remote--format-commit-url-as-sourcehut (repo-url commithash)
   "Commit URL formatted for sourcehut."
   (format "%s/commit/%s" repo-url commithash))
+
+(defun browse-at-remote--format-region-url-as-pagure (repo-url location filename &optional linestart lineend)
+  (let* ((repo-url (s-replace "/forks/" "/fork/" repo-url))
+         (markup_ext (list ".rst" ".mk" ".md" ".markdown"))
+         (markup? (seq-contains (mapcar (lambda (x) (string-suffix-p x filename)) markup_ext) t))
+         (filename (cond (markup? (concat filename "?text=True"))
+                         (t filename))))
+    (cond
+     ((and linestart lineend)
+      (format "%s/blob/%s/f/%s#_%d-%d" repo-url location filename linestart lineend))
+     (linestart (format "%s/blob/%s/f/%s#_%d" repo-url location filename linestart))
+     (t (format "%s/blob/%s/f/%s" repo-url location filename)))))
+
+(defun browse-at-remote--format-commit-url-as-pagure (repo-url commithash)
+  "Commit URL formatted for github"
+  (format "%s/commit/%s" repo-url commithash))
+
 
 (defun browse-at-remote--commit-url (commithash)
   "Return the URL to browse COMMITHASH."

--- a/readme.rst
+++ b/readme.rst
@@ -48,6 +48,7 @@ Two solution available:
    - gist.github.com
    - Phabricator
    - git.sr.ht
+   - pagure.io
 
 
 2. Set specific remote-type directly in git repo. For example, if your repository is hosted on GitHub enterprise, you should add following setting to its config::
@@ -120,6 +121,7 @@ Contributors:
 - `@kuba-orlik`_
 - `@jwhitbeck`_
 - `@microamp`_
+- `@FrostyX`_
 
 Changelog:
 --------
@@ -184,5 +186,6 @@ TODO:
 .. _`@kuba-orlik`: https://github.com/kuba-orlik
 .. _`@jwhitbeck`: https://github.com/jwhitbeck
 .. _`@microamp`: https://github.com/microamp
+.. _`@FrostyX`: https://github.com/FrostyX
 .. _stash-remote: https://github.com/rmuslimov/browse-at-remote/pull/34/files
 .. _gnu-savannah-remote: https://github.com/rmuslimov/browse-at-remote/pull/46/files

--- a/test/api-basic-test.el
+++ b/test/api-basic-test.el
@@ -59,3 +59,28 @@
   (should (equal (browse-at-remote--get-url-from-remote "git@github.com:someplace/without-ending")
                                  (cons `"github.com" `"https://github.com/someplace/without-ending")))
   )
+
+(ert-deftest get-repo-url-pagure ()
+  (let ((repo-url "https://pagure.io/copr/copr")
+	(location "master")
+	(filename "frontend/coprs_frontend/manage.py"))
+
+      (should (equal
+	(browse-at-remote--format-region-url-as-pagure repo-url location filename)
+	"https://pagure.io/copr/copr/blob/master/f/frontend/coprs_frontend/manage.py"))
+
+      (should (equal
+	(browse-at-remote--format-region-url-as-pagure repo-url location filename 12)
+	"https://pagure.io/copr/copr/blob/master/f/frontend/coprs_frontend/manage.py#_12"))
+
+      (should (equal
+	(browse-at-remote--format-region-url-as-pagure repo-url location filename 12 14)
+	"https://pagure.io/copr/copr/blob/master/f/frontend/coprs_frontend/manage.py#_12-14"))
+
+      (should (equal
+        (browse-at-remote--format-region-url-as-pagure repo-url location "README.md" 12 14)
+        "https://pagure.io/copr/copr/blob/master/f/README.md?text=True#_12-14"))
+
+      (should (equal
+        (browse-at-remote--format-region-url-as-pagure "https://pagure.io/forks/frostyx/copr/copr" location filename)
+        "https://pagure.io/fork/frostyx/copr/copr/blob/master/f/frontend/coprs_frontend/manage.py"))))


### PR DESCRIPTION
Fedora uses its own solution for hosting git repositories,
called Pagure. It is used for

- Upstream projects - pagure.io
- Distgit packages - src.fedoraproject.org

I am adding support for these two services. The implementation
is based on my Vim plugin [FrostyX/vim-fugitive-pagure](https://github.com/FrostyX/vim-fugitive-pagure) which
provides this exact feature.