### PR TITLE
Use the local branch name instead of asking

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -173,10 +173,7 @@ If HEAD is detached, return nil."
       ;; Split into two-item list, then convert to a pair.
       (apply #'cons
              (s-split-up-to "/" (s-trim remote-and-branch) 1))
-
-      ;; Ask user if worst case (TODO: replace with competing-read here)
-      (let ((remote-branch (read-string "Select remote branch: ")))
-        (cons (car (browse-at-remote--get-remotes)) remote-branch)))))
+      (cons (car (browse-at-remote--get-remotes)) local-branch))))
 
 (defun browse-at-remote--get-remote-url (remote)
   "Get URL of REMOTE from current repo."


### PR DESCRIPTION
The code already selects the first remote available so asking about the branch name is a bit pointless, it's most likely going to have the same name as the local one.

A better ask would be providing a select list of all the remote branches (remote name + branch name) but this is an entirely different feature.