### PR TITLE
More permissive regex in browse-at-remote--gerrit-url-cleanup

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -403,7 +403,7 @@ Currently the same as for github."
 (defun browse-at-remote--gerrit-url-cleanup (repo-url)
   "Remove -review from REPO-URL, so we end up at gitiles instead of gerrit"
   (replace-regexp-in-string
-   "^\\(https?://\\)\\([a-z]+\\)-review\\(\\.googlesource\\.com/\\)"
+   "^\\(https?://\\)\\([A-Za-z0-9-]+\\)-review\\(\\.googlesource\\.com/\\)"
    "\\1\\2\\3"
    repo-url))
 


### PR DESCRIPTION
Allow a larger variety of domain names to be matched by this regex.
For example, chrome-internal-review.googlesource.com.