### PR TITLE
Break `git remote` output at line boundaries.

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -202,7 +202,7 @@ If HEAD is detached, return nil."
     (vc-git--call t "remote")
     (let ((remotes (s-trim (buffer-string))))
       (unless (string= remotes "")
-        (s-split "\\W+" remotes)))))
+        (s-lines remotes)))))
 
 (defun browse-at-remote--get-remote-type-from-config ()
   "Get remote type from current repo."


### PR DESCRIPTION
The prior version of this function uses `(s-split "\\W+" remotes)` to turn the
output from `git remote` into a list of remote names, but "\\W+" matches any run
of characters that is not a word constituent, including '-', so remote names
containing hyphens get broken into two strings. `git remote` prints one remote
name per line, so breaking on lines makes more sense.

For example (strictly hypothetically), suppose we have:

    $ git remote
    gfx-rs
    jimblandy
    kvark
    $

In the prior code, this produces the list:

    ("gfx" "rs" "jimblandy" "kvark")

and things don't end well. Breaking on lines produces:

    ("gfx-rs" "jimblandy" "kvark")