### PR TITLE
Fix stash URL for detached head.

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -280,7 +280,7 @@ If HEAD is detached, return nil."
   "URL formatted for stash"
 	(let* ((branch (cond
                   ((string= location "master") "")
-                  (t (string-join (list "?at=refs%2Fheads%2F" location)))))
+                  (t (string-join (list "?at=" location)))))
          (lines (cond
                  (lineend (format "#%d-%d" linestart lineend))
                  (linestart (format "#%d" linestart))


### PR DESCRIPTION
Fixes #85 

If browse-at-remote is called on detached head or
with browse-at-remote-prefer-symbolic set to nil, location is a commit
hash. Which produces URLs like

> https://stash.../browse/file.js?at=refs%2Fheads%2Fabcdef1234567890abcdef01234567890abcdef0#1

This URL is not recognised by stash. Stash expect the URL of
format (note lack of 'refs%2Fheads'):

> https://stash.../browse/file.js?at=abcdef1234567890abcdef01234567890abcdef0#1

Remove 'refs/heads' prefix frome the URL. That will also remove the
prefix for branches and tags, but Stash works if the branch name
specified without 'refs/heads'. For example both URLs produce the same result:

> https://stash.../browse/file.js?at=BRANCH
> https://stash.../browse/file.js?at=refs%2Fheads%2FBRANCH