### PR TITLE
pagure: fix browsing commits

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -399,7 +399,7 @@ Currently the same as for github."
 
 (defun browse-at-remote--format-commit-url-as-pagure (repo-url commithash)
   "Commit URL formatted for github"
-  (format "%s/commit/%s" repo-url commithash))
+  (format "%s/c/%s" repo-url commithash))
 
 (defun browse-at-remote--gerrit-url-cleanup (repo-url)
   "Remove -review from REPO-URL, so we end up at gitiles instead of gerrit"


### PR DESCRIPTION
I am not sure if it wasn't working in the first place or if Pagure
changed the commit URLs but the original:

https://pagure.io/fedora-infra/ansible/commit/26474d6

doesn't work. This does:

https://pagure.io/fedora-infra/ansible/c/26474d6