### PR TITLE
Add defcustom to configure a path between host and filename

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -97,6 +97,11 @@ By default is true."
   "List of domains where the web URL should be http."
   :type '(repeat string))
 
+(defcustom browse-at-remote-append-path-to-host nil
+  "Path to append at the end of the HTTP host before the filename name."
+  :type 'string
+  :group 'browse-at-remote)
+
 (defun browse-at-remote--get-url-from-remote (remote-url)
   "Return (DOMAIN . URL) from REMOTE-URL."
   ;; If the protocol isn't specified, git treats it as an SSH URL.

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -112,6 +112,7 @@ By default is true."
          (port (url-port-if-non-default parsed))
          (web-proto
           (if (equal (url-type parsed) "http") "http" "https"))
+         (path (or browse-at-remote-append-path-to-host ""))
          (filename (url-filename parsed)))
     ;; SSH URLs can contain colons in the host part, e.g. ssh://example.com:foo.
     (when (s-contains-p ":" host)

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -130,7 +130,7 @@ By default is true."
     (when port
       (setq host (format "%s:%d" host port)))
     (cons host
-          (format "%s://%s%s" web-proto host filename))))
+          (format "%s://%s%s%s" web-proto host path filename))))
 
 (defun browse-at-remote--remote-ref (&optional filename)
   "Return (REMOTE-URL . REF) which contains FILENAME.


### PR DESCRIPTION
I ran into an issue where my remote type was using `gitiles` type, but between the host and the filename there was a custom path. At first, I tried to solve this with `add-advice` but it quickly became a mess, so it was much easier to provide this as an option.

`browse-at-remote-append-path-to-host` allows users of the package to customize the remote URL if needed:

```
<web-proto>://<host><path><filename>
```

This is my first PR to an emacs package so I'm not sure if this is the best way to go about it.