### PR TITLE
Add support for Codeberg remotes

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -7,7 +7,7 @@
 browse-at-remote.el
 ===================
 
-This package is easiest way to open particular link on *github*/*gitlab*/*bitbucket*/*stash*/*git.savannah.gnu.org*/*sourcehut* from Emacs. It supports various kind of emacs buffer, like:
+This package is easiest way to open particular link on *github*/*gitlab*/*bitbucket*/*stash*/*git.savannah.gnu.org*/*sourcehut*/*codeberg* from Emacs. It supports various kind of emacs buffer, like:
 
 - file buffer
 - dired buffer
@@ -61,6 +61,7 @@ Two solution available:
    - git.sr.ht
    - pagure.io
    - vs-ssh.visualstudio.com
+   - codeberg.org
 
 
 2. Set specific remote-type directly in git repo. For example, if your repository is hosted on GitHub enterprise, you should add following setting to its config::
@@ -166,6 +167,7 @@ Contributors:
 - `@FrostyX`_
 - `@legendary-mich`_
 - `@ilmotta`_
+- `@akreisher`_
 
 Changelog:
 --------


### PR DESCRIPTION
This PR adds support for browsing [codeberg.org](codeberg.org) remotes.

Since the codeberg region URL depends on whether the location is a symbolic branch name or a commit hash, I updated the return of `browse-at-remote--remote-ref` to return whether the ref is a branch name or commit hash unambiguously. I updated the call to the `fomat-region-url-as-*` functions to include this `location-type`. Right now it is only used by the codeberg formatter. 