### PR TITLE
Mention the new name for Stash (Bitbucket Server)

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -54,7 +54,7 @@ Two solution available:
    - bitbucket.com
    - gitlab.com
    - github.com
-   - Stash
+   - Stash (now called Bitbucket Server, use this if your url looks like `bitbucket.yourcompany.com`)
    - git.savannah.gnu.org
    - gist.github.com
    - Phabricator


### PR DESCRIPTION
When browse-at-remote didn't work for my employer's repositories, I tried to grep the README for `bitbucket` and none of the solutions worked. I now became aware that Bitbucket Server used to be called "Stash", but it would never have crossed my mind to search for "stash". I hope that this note will help someone else like me avoid the confusion.