### PR TITLE
Add support for 'kernel.org' git repos

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -66,7 +66,8 @@
   '((:host "^github\\.com$"               :type "github")
     (:host "^bitbucket\\.org$"            :type "bitbucket")
     (:host "^gitlab\\.com$"               :type "gitlab")
-    (:host "^git\\.savannah\\.gnu\\.org$" :type "gnu")
+    (:host "^git\\.savannah\\.gnu\\.org$" :type "gnu" :actual-host "git.savannah.gnu.org/cgit")
+    (:host "^git\\.kernel\\.org$"         :type "gnu")
     (:host "^gist\\.github\\.com$"        :type "gist")
     (:host "^git\\.sr\\.ht$"              :type "sourcehut")
     (:host "^.*\\.visualstudio\\.com$"    :type "ado")
@@ -283,7 +284,7 @@ related remote in `browse-at-remote-remote-type-regexps'."
    (domain (butlast parts))
    (project (car (last parts))))
     (string-join
-     (append domain (list "cgit" project)) "/")))
+     (append domain (list project)) "/")))
 
 (defun browse-at-remote--format-region-url-as-gnu (repo-url location filename &optional linestart lineend)
   "URL formatter for gnu."

--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -53,7 +53,7 @@
                                        (const :tag "GitLab" "gitlab")
                                        (const :tag "Bitbucket" "bitbucket")
                                        (const :tag "Stash/Bitbucket Server" "stash")
-                                       (const :tag "git.savannah.gnu.org" "gnu")
+                                       (const :tag "cgit" "gnu")
                                        (const :tag "Azure DevOps" "ado")
                                        (const :tag "Phabricator" "phabricator")
                                        (const :tag "gist.github.com" "gist")

--- a/readme.rst
+++ b/readme.rst
@@ -55,7 +55,7 @@ Two solution available:
    - gitlab.com
    - github.com
    - Stash
-   - git.savannah.gnu.org
+   - Cgit
    - gist.github.com
    - Phabricator
    - git.sr.ht


### PR DESCRIPTION
Kernel.org uses cgit as web-frontend, same as GNU Savannah but the configuration is slightly different. Gnu Savannah hosts cgit under `/cgit` prefix while `git.kernel.org` does not use such prefix. 

 Allow `gnu` remote to work with arbitrary Cgit instances and add `kernel.org` to the default list of supported hosts.