### PR TITLE
Added Gitea support

### DIFF
--- a/browse-at-remote.el
+++ b/browse-at-remote.el
@@ -1,4 +1,4 @@
-;;; browse-at-remote.el --- Open github/gitlab/bitbucket/stash/gist/phab/sourcehut page from Emacs -*- lexical-binding:t -*-
+;;; browse-at-remote.el --- Open github/gitlab/bitbucket/stash/gist/phab/sourcehut/gitea page from Emacs -*- lexical-binding:t -*-
 
 ;; Copyright © 2015-2023
 ;;

--- a/readme.rst
+++ b/readme.rst
@@ -7,7 +7,7 @@
 browse-at-remote.el
 ===================
 
-This package is easiest way to open particular link on *github*/*gitlab*/*bitbucket*/*stash*/*git.savannah.gnu.org*/*sourcehut* from Emacs. It supports various kind of emacs buffer, like:
+This package is easiest way to open particular link on *github*/*gitlab*/*bitbucket*/*stash*/*git.savannah.gnu.org*/*sourcehut*/*gitea* from Emacs. It supports various kind of emacs buffer, like:
 
 - file buffer
 - dired buffer
@@ -61,6 +61,7 @@ Two solution available:
    - git.sr.ht
    - pagure.io
    - vs-ssh.visualstudio.com
+   - gitea
 
 
 2. Set specific remote-type directly in git repo. For example, if your repository is hosted on GitHub enterprise, you should add following setting to its config::


### PR DESCRIPTION
Adds first-class support for self-hosted [Gitea](https://about.gitea.com/) instances to **browse-at-remote**.

It introduces URL formatting for file regions and commits, and extends the host-type detection so the package correctly handles Gitea remotes — including repositories with dotted names such as .emacs.d.

Since gitea can be cloud based or selfhosted. In case of selfhosted on a custom domain here is the Emacs config
```emacs-lisp
(use-package browse-at-remote
  :config
  ;; Tell browse-at-remote that kentavros.lan uses Gitea
  (add-to-list 'browse-at-remote-remote-type-regexps
               '(:host "my-domain\\.local$" :type "gitea"))
  )
``` 